### PR TITLE
Fix Postman API key links

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ claude --plugin-dir /path/to/postman-claude-code-plugin
 
 That's it. The plugin auto-configures the Postman MCP Server, verifies your connection, and lists your workspaces. You're ready to go.
 
-Get your API key at [postman.postman.co/settings/me/api-keys](https://postman.postman.co/settings/me/api-keys).
+Get your API key at [go.postman.co/settings/me/api-keys](https://go.postman.co/settings/me/api-keys).
 
 ## Commands
 
@@ -170,5 +170,5 @@ Apache-2.0
 ## Links
 
 - [Postman MCP Server Docs](https://learning.postman.com/docs/developer/postman-mcp-server/)
-- [Get a Postman API Key](https://postman.postman.co/settings/me/api-keys)
+- [Get a Postman API Key](https://go.postman.co/settings/me/api-keys)
 - [Postman Status](https://status.postman.com)

--- a/commands/codegen.md
+++ b/commands/codegen.md
@@ -88,6 +88,6 @@ Generated: src/clients/users-api.ts
 
 - **MCP not configured:** "Run `/postman:setup` to configure the Postman MCP Server."
 - **Collection not found:** "No collection matching that name. Run `/postman:search` to find available APIs."
-- **401 Unauthorized:** "Your Postman API key was rejected. Generate a new one at https://postman.postman.co/settings/me/api-keys and run `/postman:setup`."
+- **401 Unauthorized:** "Your Postman API key was rejected. Generate a new one at https://go.postman.co/settings/me/api-keys and run `/postman:setup`."
 - **Empty collection:** "This collection has no requests. Add endpoints in Postman or use `/postman:sync` to push a spec."
 - **Language not detected:** Ask the user what language to generate.

--- a/commands/docs.md
+++ b/commands/docs.md
@@ -82,7 +82,7 @@ If both a spec and collection exist, keep them in sync:
 ## Error Handling
 
 - **MCP not configured:** Local markdown docs can be generated without MCP. For Postman publishing: "Run `/postman:setup` to configure the Postman MCP Server."
-- **401 Unauthorized:** "Your Postman API key was rejected. Generate a new one at https://postman.postman.co/settings/me/api-keys and run `/postman:setup`."
+- **401 Unauthorized:** "Your Postman API key was rejected. Generate a new one at https://go.postman.co/settings/me/api-keys and run `/postman:setup`."
 - **Invalid spec:** Report parse errors and offer to fix common YAML/JSON syntax issues.
 - **Plan limitations:** "Publishing documentation may require a paid Postman plan. Check https://www.postman.com/pricing/"
 - **Too many results:** Ask the user to specify a collection by name.

--- a/commands/mock.md
+++ b/commands/mock.md
@@ -96,6 +96,6 @@ If the user wants the mock publicly accessible:
 
 - **MCP not configured:** "Run `/postman:setup` to configure the Postman MCP Server."
 - **No examples in collection:** Auto-generate from schemas (Step 2). If no schemas either, ask the user to provide sample responses.
-- **401 Unauthorized:** "Your Postman API key was rejected. Generate a new one at https://postman.postman.co/settings/me/api-keys and run `/postman:setup`."
+- **401 Unauthorized:** "Your Postman API key was rejected. Generate a new one at https://go.postman.co/settings/me/api-keys and run `/postman:setup`."
 - **MCP timeout:** Retry once. If it still fails, check https://status.postman.com for outages.
 - **Plan limitations:** "Mock server creation may require a Postman Basic plan or higher for increased usage limits."

--- a/commands/search.md
+++ b/commands/search.md
@@ -74,5 +74,5 @@ List relevant collections with endpoint counts, then ask which to explore furthe
 
 - **MCP not configured:** "Run `/postman:setup` to configure the Postman MCP Server."
 - **No results:** "Nothing matched in your private API network. Try different keywords, browse in user's workspaces, or search the public Postman network."
-- **401 Unauthorized:** "Your Postman API key was rejected. Generate a new one at https://postman.postman.co/settings/me/api-keys and run `/postman:setup`."
+- **401 Unauthorized:** "Your Postman API key was rejected. Generate a new one at https://go.postman.co/settings/me/api-keys and run `/postman:setup`."
 - **Too many results:** Ask the user to be more specific. Suggest filtering by workspace or using tags.

--- a/commands/security.md
+++ b/commands/security.md
@@ -123,7 +123,7 @@ After fixes, re-run the audit to show improvement.
 ## Error Handling
 
 - **MCP not configured:** Local spec auditing works without MCP. For Postman-specific checks: "Run `/postman:setup` to configure the Postman MCP Server."
-- **401 Unauthorized:** "Your Postman API key was rejected. Generate a new one at https://postman.postman.co/settings/me/api-keys and run `/postman:setup`."
+- **401 Unauthorized:** "Your Postman API key was rejected. Generate a new one at https://go.postman.co/settings/me/api-keys and run `/postman:setup`."
 - **No spec found:** Ask the user for the path. Offer to audit a Postman collection directly via MCP.
 - **Spec too large:** For large specs (100+ endpoints), audit in batches by tag or path prefix.
 - **Plan limitations:** "Some audit features may require a paid Postman plan. Check https://www.postman.com/pricing/"

--- a/commands/setup.md
+++ b/commands/setup.md
@@ -22,7 +22,7 @@ Verify the Postman MCP Server is available by calling `getAuthenticatedUser`.
 ```
 Let's set up Postman for Claude Code.
 
-1. Go to: https://postman.postman.co/settings/me/api-keys
+1. Go to: https://go.postman.co/settings/me/api-keys
 2. Click "Generate API Key"
 3. Name it "Claude Code"
 4. Copy the key (starts with PMAK-)
@@ -36,7 +36,7 @@ Add it to your shell profile (~/.zshrc or ~/.bashrc) to persist across sessions.
 
 Wait for the user to confirm they've set the key. Then verify with `getAuthenticatedUser`.
 
-**If 401:** "API key was rejected. Check for extra spaces or generate a new one at https://postman.postman.co/settings/me/api-keys"
+**If 401:** "API key was rejected. Check for extra spaces or generate a new one at https://go.postman.co/settings/me/api-keys"
 
 **If timeout:** "Can't reach the Postman MCP Server. Check your network and https://status.postman.com"
 
@@ -94,6 +94,6 @@ Try this:
 
 - **MCP tools not available:** "The Postman MCP Server isn't loaded. Make sure the plugin is installed and restart Claude Code."
 - **API key not set:** Walk through Step 2 above.
-- **401 Unauthorized:** "Your API key was rejected. Generate a new one at https://postman.postman.co/settings/me/api-keys"
+- **401 Unauthorized:** "Your API key was rejected. Generate a new one at https://go.postman.co/settings/me/api-keys"
 - **Network timeout:** "Can't reach the Postman MCP Server. Check your network and https://status.postman.com for outages."
 - **Plan limitations:** "Some features (team workspaces, monitors) require a paid Postman plan. Core commands work on all plans."

--- a/commands/sync.md
+++ b/commands/sync.md
@@ -79,7 +79,7 @@ Collection synced: "Pet Store API" (15 requests)
 
 - **MCP not configured:** "Run `/postman:setup` to configure the Postman MCP Server."
 - **MCP timeout:** Retry once. If `generateCollection` or `syncCollectionWithSpec` times out, the spec may be too large. Suggest breaking it into smaller specs by domain.
-- **401 Unauthorized:** "Your Postman API key was rejected. Generate a new one at https://postman.postman.co/settings/me/api-keys and run `/postman:setup`."
+- **401 Unauthorized:** "Your Postman API key was rejected. Generate a new one at https://go.postman.co/settings/me/api-keys and run `/postman:setup`."
 - **Invalid spec:** Report specific parse errors with line numbers. Offer to fix common YAML/JSON syntax issues.
 - **Async operation stuck:** If polling shows no progress after 30 seconds, inform the user and suggest checking the Postman app directly.
 - **Plan limitations:** "Workspace creation may be limited on free plans. Using your default workspace instead."

--- a/commands/test.md
+++ b/commands/test.md
@@ -79,6 +79,6 @@ If the tests themselves need updating (not the API):
 
 - **MCP not configured:** "Run `/postman:setup` to configure the Postman MCP Server."
 - **Collection not found:** "No collection matching that name. Run `/postman:search` to find available collections, or `/postman:sync` to create one."
-- **401 Unauthorized:** "Your Postman API key was rejected. Generate a new one at https://postman.postman.co/settings/me/api-keys and run `/postman:setup`."
+- **401 Unauthorized:** "Your Postman API key was rejected. Generate a new one at https://go.postman.co/settings/me/api-keys and run `/postman:setup`."
 - **MCP timeout:** Retry once. For large collections, suggest running a single folder to narrow the test run.
 - **Plan limitations:** "Collection runs may require a Postman Basic plan or higher for increased limits."


### PR DESCRIPTION
# About 
This PR updates all references to the Postman API key URL throughout the documentation and error messages, changing them from `postman.postman.co/settings/me/api-keys` to `go.postman.co/settings/me/api-keys`.

# Why it needs to be updated
`postman.postman.co/settings/me/api-keys` is the API keys page URL intended for the team whose team domain is `postman`. The correct URL for all users is go.postman.co/settings/me/api-keys.