### PR TITLE
fix: use pull_request_target for labeler to support fork PRs

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,7 +1,7 @@
 name: PR Labeler
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened]
 
 permissions:


### PR DESCRIPTION
## Problem

The current `PR Labeler` workflow uses the `pull_request` event, which restricts `GITHUB_TOKEN` to read-only permissions for PRs from forked repositories. This causes the labeler to fail with a permission error when external contributors open PRs.

An example of the labeler failing in this problem:  
- CI `PR Labeler` failed due to permission issue - [Action](https://github.com/Postman-Devrel/postman-claude-code-plugin/actions/runs/24254127284/job/70821112509?pr=2)  for PR https://github.com/Postman-Devrel/postman-claude-code-plugin/pull/2

## Solution

Change the trigger from `pull_request` to `pull_request_target`, which runs in the context of the base repository and allows `pull-requests: write` to work correctly for fork PRs.

relevant link: https://github.com/actions/labeler?tab=readme-ov-file#recommended-permissions

## Note

`pull_request_target` can be a security risk if forked code is checked out and executed. This workflow only adds labels and does not checkout any code, so this change is safe.
