### PR TITLE
Add Postman Flows CLI skills and slash commands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,7 @@ Several commands use the Postman CLI instead of MCP. They require `postman-cli` 
 - `/postman:list-flows` — List flows in a workspace and resolve a flow name to its 24-char ID via `postman flows list`
 - `/postman:trigger-flow` — Trigger a deployed flow via `postman flows trigger`, with a deploy-then-trigger fallback when the flow isn't deployed
 - `/postman:deploy-flow` — Deploy a flow to make it triggerable via `postman flows deploy` (proposes and confirms a trigger path first)
-- `/postman:get-flow-run` — Inspect a run by Run ID via `postman flows get-run` (per-block logs, failing block, status, credits)
+- `/postman:get-flow-run` — Inspect a run by Run ID via `postman flows get-run` (per-block logs, failing block, status)
 
 CLI commands work with Postman's git sync structure: `postman/collections/` (v3 folder format), `postman/environments/`, `postman/specs/`, and `.postman/resources.yaml` for cloud ID mapping.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,8 +11,8 @@ The Postman Plugin for Claude Code — a pure-markdown, configuration-driven plu
 ```
 .claude-plugin/plugin.json   # Plugin manifest (name, version, metadata)
 .mcp.json                    # MCP server auto-config (Postman MCP at mcp.postman.com)
-commands/*.md                # 11 slash commands (/postman:<name>)
-skills/*/SKILL.md            # 7 skills (knowledge, agent-ready APIs, CLI, send-request, generate-spec, run-collection, context)
+commands/*.md                # 15 slash commands (/postman:<name>)
+skills/*/SKILL.md            # 11 skills (knowledge, agent-ready APIs, CLI, send-request, generate-spec, run-collection, context, and Flows: list-flows, trigger-flow, deploy-flow, get-flow-run)
 skills/*/references/*.md     # On-demand reference files loaded by skills only when needed
 agents/readiness-analyzer.md # Sub-agent for API readiness analysis
 examples/                    # Sample output (readiness report)
@@ -31,7 +31,7 @@ examples/                    # Sample output (readiness report)
 
 **Commands** (`commands/*.md`): YAML front matter with `description` and `allowed-tools`. Each defines a structured workflow invoked as `/postman:<name>`.
 - MCP commands: setup, sync, search, test, mock, docs, security, learn (learn requires Full mode — `searchLearningCenter` is absent in `minimal`/`code`)
-- CLI commands: request, generate-spec, run-collection
+- CLI commands: request, generate-spec, run-collection, list-flows, trigger-flow, deploy-flow, get-flow-run
 
 **Skills** (`skills/*/SKILL.md`): YAML front matter with `name`, `description`, `user-invocable`. Auto-injected context, not directly invoked. `postman-knowledge` provides MCP tool guidance; `agent-ready-apis` provides readiness criteria; `postman-cli` provides CLI and git sync file structure knowledge; `postman-context` provides API discovery, exploration, and code generation from real API definitions.
 
@@ -51,12 +51,16 @@ These are documented in `skills/postman-knowledge/mcp-limitations.md` and must b
 
 ## Postman CLI Commands
 
-Three commands use the Postman CLI instead of MCP. They require `postman-cli` installed locally (`npm install -g postman-cli`) and authenticated (`postman login`). If CLI is not found, show install instructions and stop.
+Several commands use the Postman CLI instead of MCP. They require `postman-cli` installed locally (`npm install -g postman-cli`) and authenticated (`postman login`). If CLI is not found, show install instructions and stop.
 
 - `/postman:request` — Send HTTP requests via `postman request <METHOD> <URL>`
 - `/postman:generate-spec` — Scan code for API routes, generate OpenAPI 3.0 YAML, validate with `postman spec lint`
 - `/postman:run-collection` — Run collection tests via `postman collection run <id>` using cloud IDs from `.postman/resources.yaml`
 - `/postman:context` — Discover, explore, and install APIs via `postman context`. Searches Postman's API network, fetches real API definitions, and generates client code from them.
+- `/postman:list-flows` — List flows in a workspace and resolve a flow name to its 24-char ID via `postman flows list`
+- `/postman:trigger-flow` — Trigger a deployed flow via `postman flows trigger`, with a deploy-then-trigger fallback when the flow isn't deployed
+- `/postman:deploy-flow` — Deploy a flow to make it triggerable via `postman flows deploy` (proposes and confirms a trigger path first)
+- `/postman:get-flow-run` — Inspect a run by Run ID via `postman flows get-run` (per-block logs, failing block, status, credits)
 
 CLI commands work with Postman's git sync structure: `postman/collections/` (v3 folder format), `postman/environments/`, `postman/specs/`, and `.postman/resources.yaml` for cloud ID mapping.
 

--- a/commands/deploy-flow.md
+++ b/commands/deploy-flow.md
@@ -1,0 +1,22 @@
+---
+description: Deploy a Postman Flow so it becomes triggerable, proposing and confirming a trigger path
+allowed-tools: Bash, Read
+---
+
+Deploy a Postman Flow using the Postman CLI. Follow the `deploy-flow` skill.
+
+## Inputs (from the user's message)
+- The flow (a 24-char ID, or a name to resolve via `list-flows`)
+- Optionally a desired trigger path and whether auth is required
+
+## Steps
+1. Resolve the flow ID (use `list-flows` if given a name; ask for the workspace if unknown).
+2. Propose a trigger path derived from the flow name (e.g. "Checkout" → `/checkout`) and **confirm the path + the deploy action** with the user — deploy is mutating and MUST NOT run without explicit confirmation.
+3. Show the command, then run it after confirmation:
+   ```bash
+   POSTMAN_CLI_SOURCE=claude-code-plugin postman flows deploy <flowId> --path /checkout
+   ```
+4. Report the **Trigger URL** and whether the **trigger is enabled**. If it's off, offer `postman flows update <flowId> --trigger on` (confirm first).
+5. If this was part of a deploy-then-trigger request, hand back to `trigger-flow` to run it.
+
+Always prefix CLI calls with `POSTMAN_CLI_SOURCE=claude-code-plugin`. Reuse existing `postman login` credentials — never authenticate twice.

--- a/commands/get-flow-run.md
+++ b/commands/get-flow-run.md
@@ -1,0 +1,22 @@
+---
+description: Inspect a Postman Flow run by its Run ID — per-block logs, failing block, status, and credits consumed
+allowed-tools: Bash, Read
+---
+
+Inspect a specific Postman Flow run using the Postman CLI. Follow the `get-flow-run` skill.
+
+## Inputs (from the user's message)
+- The Run ID (the `x-run-id` that `trigger-flow` reported; ask if unknown)
+- Optionally a block ID to focus on
+
+## Steps
+1. Take the Run ID.
+2. Run a summary, then add `--logs` for detail:
+   ```bash
+   POSTMAN_CLI_SOURCE=claude-code-plugin postman flows get-run --run-id <runId>
+   POSTMAN_CLI_SOURCE=claude-code-plugin postman flows get-run --run-id <runId> --logs
+   ```
+   Narrow to a block with `--filter <blockId>`.
+3. Report **which block failed and why**, the **run status**, and **credits consumed** when the run history exposes it (say so if it doesn't, rather than inventing a number).
+
+Read-only: no confirmation needed. Prefix CLI calls with `POSTMAN_CLI_SOURCE=claude-code-plugin`. Reuse existing `postman login` credentials.

--- a/commands/get-flow-run.md
+++ b/commands/get-flow-run.md
@@ -1,5 +1,5 @@
 ---
-description: Inspect a Postman Flow run by its Run ID — per-block logs, failing block, status, and credits consumed
+description: Inspect a Postman Flow run by its Run ID — per-block logs, failing block, and status
 allowed-tools: Bash, Read
 ---
 
@@ -17,6 +17,6 @@ Inspect a specific Postman Flow run using the Postman CLI. Follow the `get-flow-
    POSTMAN_CLI_SOURCE=claude-code-plugin postman flows get-run --run-id <runId> --logs
    ```
    Narrow to a block with `--filter <blockId>`.
-3. Report **which block failed and why**, the **run status**, and **credits consumed** when the run history exposes it (say so if it doesn't, rather than inventing a number).
+3. Report **which block failed and why** and the **run status**.
 
 Read-only: no confirmation needed. Prefix CLI calls with `POSTMAN_CLI_SOURCE=claude-code-plugin`. Reuse existing `postman login` credentials.

--- a/commands/list-flows.md
+++ b/commands/list-flows.md
@@ -1,0 +1,21 @@
+---
+description: List Postman Flows in a workspace and resolve a flow name to its 24-character ID
+allowed-tools: Bash, Read
+---
+
+List Postman Flows in a workspace using the Postman CLI. Follow the `list-flows` skill.
+
+## Inputs (from the user's message)
+- The workspace ID (ask if unknown)
+- Optionally a name/pattern to filter by
+
+## Steps
+1. Ensure you have a workspace ID; ask which workspace if not.
+2. Run:
+   ```bash
+   POSTMAN_CLI_SOURCE=claude-code-plugin postman flows list --workspace <workspaceId>
+   ```
+   Narrow with `--filter "<name>"` when resolving a specific flow; use `--sort name` / `--paginate` as needed.
+3. Report flow **names + IDs** (and recent status where shown). When resolving a name for another action, return the single matching ID, or present candidates and ask the user to choose on multiple matches — never guess.
+
+Read-only: no confirmation needed. Prefix CLI calls with `POSTMAN_CLI_SOURCE=claude-code-plugin`. Reuse existing `postman login` credentials.

--- a/commands/trigger-flow.md
+++ b/commands/trigger-flow.md
@@ -1,0 +1,24 @@
+---
+description: Trigger (run) a deployed Postman Flow with inputs, and deploy-then-trigger it if it isn't deployed yet
+allowed-tools: Bash, Read
+---
+
+Trigger a deployed Postman Flow from natural language, using the Postman CLI. Follow the `trigger-flow` skill.
+
+## Inputs (from the user's message)
+- The flow (a 24-char ID, or a name to resolve via `list-flows`)
+- Any inputs / query params / headers / scenario
+- The workspace ID (ask if a name needs resolving and you don't have it)
+
+## Steps
+1. Resolve the flow ID (use `list-flows` if given a name; disambiguate multiple matches; ask for the workspace if unknown).
+2. Build the flags from natural language: `-i k=v`, `-q k=v`, `--headers k=v`, `-s "<scenario>"`.
+3. Show the command, then run it:
+   ```bash
+   POSTMAN_CLI_SOURCE=claude-code-plugin postman flows trigger <flowId> -i amount=4200
+   ```
+4. Report the **Run ID**, **HTTP status**, and **response body**.
+5. If not deployed → explain and **offer to deploy** (via `deploy-flow`, explicit confirmation required), then re-trigger. If the trigger is disabled → offer `postman flows update <flowId> --trigger on` (confirm), then trigger.
+6. On a non-2xx response → surface status + body and offer `get-flow-run --run-id <id>` for per-block detail.
+
+Always prefix CLI calls with `POSTMAN_CLI_SOURCE=claude-code-plugin`. Reuse existing `postman login` credentials — never authenticate twice. Confirm before any mutating action (deploy, enable trigger).

--- a/skills/deploy-flow/SKILL.md
+++ b/skills/deploy-flow/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: deploy-flow
+description: Deploy a Postman Flow so it becomes triggerable, using the Postman CLI. Use when the user wants to deploy, publish, or "make a flow callable/triggerable", or when trigger-flow found a flow that isn't deployed yet and the user confirmed deploying. Deploying is a mutating action — always propose a trigger path and get explicit confirmation before running.
+---
+
+You are a Postman Flows assistant that deploys Flows using the Postman CLI. Deploying makes a flow triggerable and returns its **Trigger URL**.
+
+## When to Use This Skill
+
+Trigger this skill when the user wants to:
+- "deploy my flow", "publish the flow", "make this flow triggerable / callable"
+- as the second half of a **deploy-then-trigger** flow that `trigger-flow` started (flow wasn't deployed → user confirmed → deploy → trigger)
+
+---
+
+## The command this wraps
+
+```bash
+POSTMAN_CLI_SOURCE=claude-code-plugin postman flows deploy <flowId> --path </path> [options]
+```
+
+Options:
+- `-p, --path <path>` — **required** URL path for the trigger (e.g. `/checkout`)
+- `-t, --timeout <timeout>` — HTTP session timeout, 5000ms–60000ms (default `10000ms`)
+- `-a, --auth` — enable authentication on the trigger
+
+## Step 1: Resolve the flow ID
+
+If given a name rather than a 24-char ID, resolve it with the `list-flows` skill (ask which workspace if unknown; disambiguate on multiple matches). (FR-005 dependency)
+
+## Step 2: Propose a trigger path and CONFIRM
+
+Deploy **requires** a URL path. Propose a sensible default derived from the flow name:
+- "Checkout" → `/checkout`
+- "Nightly Report" → `/nightly-report`
+
+Then **confirm the path and the action with the user before deploying** — deploy is a mutating action and MUST NOT run without explicit confirmation. (FR-002, FR-011)
+
+Ask about authentication only if relevant ("Should the trigger require auth?"). Add `--auth` only if they say yes.
+
+## Step 3: Deploy
+
+Show the exact command, then run it after confirmation:
+
+```bash
+POSTMAN_CLI_SOURCE=claude-code-plugin postman flows deploy 12345-67890-abcdef --path /checkout
+```
+
+Report back:
+- the resulting **Trigger URL**
+- whether the **trigger is enabled**. If the CLI notes the trigger is off, tell the user and offer to enable it:
+  ```bash
+  POSTMAN_CLI_SOURCE=claude-code-plugin postman flows update 12345-67890-abcdef --trigger on
+  ```
+  (enabling is also a state change → confirm first). (FR-002, FR-004)
+
+Example report:
+```
+Deployed the Checkout flow.
+  Trigger URL: https://<host>/checkout
+  Trigger:     enabled
+```
+
+## Step 4: Hand back to trigger (if part of deploy-then-trigger)
+
+If deploying was requested so the user could run the flow, hand control back to the `trigger-flow` skill to fire it and report the Run ID + status + response — completing the deploy-then-trigger journey in one conversation. (SC-002)
+
+---
+
+## Error Handling
+
+- **CLI not installed:** "Postman CLI is not installed. Install with: `npm install -g postman-cli`"
+- **Not authenticated:** "Postman CLI needs authentication. Run: `postman login` (or set `POSTMAN_API_KEY`)." Don't re-authenticate if credentials already exist.
+- **Path conflict / invalid path:** surface the CLI's message and propose an alternative path, then re-confirm.
+
+---
+
+## Important Notes (shared authoring baseline)
+
+- **Prefix every CLI call with `POSTMAN_CLI_SOURCE=claude-code-plugin`** for telemetry attribution.
+- **Reuse existing credentials** — no second authentication. (FR-013)
+- **Never bypass entitlements** — surface CLI errors, don't assert access. (FR-014)
+- **Confirm before mutating.** Deploying and enabling a trigger both change state and require explicit user confirmation. (FR-011)

--- a/skills/deploy-flow/SKILL.md
+++ b/skills/deploy-flow/SKILL.md
@@ -26,7 +26,7 @@ Options:
 
 ## Step 1: Resolve the flow ID
 
-If given a name rather than a 24-char ID, resolve it with the `list-flows` skill (ask which workspace if unknown; disambiguate on multiple matches). (FR-005 dependency)
+If given a name rather than a 24-char ID, resolve it with the `list-flows` skill (ask which workspace if unknown; disambiguate on multiple matches).
 
 ## Step 2: Propose a trigger path and CONFIRM
 
@@ -34,7 +34,7 @@ Deploy **requires** a URL path. Propose a sensible default derived from the flow
 - "Checkout" → `/checkout`
 - "Nightly Report" → `/nightly-report`
 
-Then **confirm the path and the action with the user before deploying** — deploy is a mutating action and MUST NOT run without explicit confirmation. (FR-002, FR-011)
+Then **confirm the path and the action with the user before deploying** — deploy is a mutating action and MUST NOT run without explicit confirmation.
 
 Ask about authentication only if relevant ("Should the trigger require auth?"). Add `--auth` only if they say yes.
 
@@ -52,7 +52,7 @@ Report back:
   ```bash
   POSTMAN_CLI_SOURCE=claude-code-plugin postman flows update 12345-67890-abcdef --trigger on
   ```
-  (enabling is also a state change → confirm first). (FR-002, FR-004)
+  (enabling is also a state change → confirm first).
 
 Example report:
 ```
@@ -63,7 +63,7 @@ Deployed the Checkout flow.
 
 ## Step 4: Hand back to trigger (if part of deploy-then-trigger)
 
-If deploying was requested so the user could run the flow, hand control back to the `trigger-flow` skill to fire it and report the Run ID + status + response — completing the deploy-then-trigger journey in one conversation. (SC-002)
+If deploying was requested so the user could run the flow, hand control back to the `trigger-flow` skill to fire it and report the Run ID + status + response — completing the deploy-then-trigger journey in one conversation.
 
 ---
 
@@ -78,6 +78,6 @@ If deploying was requested so the user could run the flow, hand control back to 
 ## Important Notes (shared authoring baseline)
 
 - **Prefix every CLI call with `POSTMAN_CLI_SOURCE=claude-code-plugin`** for telemetry attribution.
-- **Reuse existing credentials** — no second authentication. (FR-013)
-- **Never bypass entitlements** — surface CLI errors, don't assert access. (FR-014)
-- **Confirm before mutating.** Deploying and enabling a trigger both change state and require explicit user confirmation. (FR-011)
+- **Reuse existing credentials** — no second authentication.
+- **Never bypass entitlements** — surface CLI errors, don't assert access.
+- **Confirm before mutating.** Deploying and enabling a trigger both change state and require explicit user confirmation.

--- a/skills/deploy-flow/SKILL.md
+++ b/skills/deploy-flow/SKILL.md
@@ -1,17 +1,9 @@
 ---
 name: deploy-flow
-description: Deploy a Postman Flow so it becomes triggerable, using the Postman CLI. Use when the user wants to deploy, publish, or "make a flow callable/triggerable", or when trigger-flow found a flow that isn't deployed yet and the user confirmed deploying. Deploying is a mutating action — always propose a trigger path and get explicit confirmation before running.
+description: Deploy a Postman Flow so it becomes triggerable, using the Postman CLI. Use when the user wants to deploy, publish, or make a flow callable, or when trigger-flow found an undeployed flow and the user confirmed.
 ---
 
 You are a Postman Flows assistant that deploys Flows using the Postman CLI. Deploying makes a flow triggerable and returns its **Trigger URL**.
-
-## When to Use This Skill
-
-Trigger this skill when the user wants to:
-- "deploy my flow", "publish the flow", "make this flow triggerable / callable"
-- as the second half of a **deploy-then-trigger** flow that `trigger-flow` started (flow wasn't deployed → user confirmed → deploy → trigger)
-
----
 
 ## The command this wraps
 
@@ -34,7 +26,7 @@ Deploy **requires** a URL path. Propose a sensible default derived from the flow
 - "Checkout" → `/checkout`
 - "Nightly Report" → `/nightly-report`
 
-Then **confirm the path and the action with the user before deploying** — deploy is a mutating action and MUST NOT run without explicit confirmation.
+Confirm the path and the deploy action with the user before running — deploy is mutating and requires explicit confirmation.
 
 Ask about authentication only if relevant ("Should the trigger require auth?"). Add `--auth` only if they say yes.
 
@@ -67,17 +59,6 @@ If deploying was requested so the user could run the flow, hand control back to 
 
 ---
 
-## Error Handling
+Read `references/flows-cli-baseline.md` for CLI prefixing, credential reuse, and error handling rules.
 
-- **CLI not installed:** "Postman CLI is not installed. Install with: `npm install -g postman-cli`"
-- **Not authenticated:** "Postman CLI needs authentication. Run: `postman login` (or set `POSTMAN_API_KEY`)." Don't re-authenticate if credentials already exist.
-- **Path conflict / invalid path:** surface the CLI's message and propose an alternative path, then re-confirm.
-
----
-
-## Important Notes (shared authoring baseline)
-
-- **Prefix every CLI call with `POSTMAN_CLI_SOURCE=claude-code-plugin`** for telemetry attribution.
-- **Reuse existing credentials** — no second authentication.
-- **Never bypass entitlements** — surface CLI errors, don't assert access.
-- **Confirm before mutating.** Deploying and enabling a trigger both change state and require explicit user confirmation.
+Deploying and enabling a trigger are mutating actions — confirm with the user before running. On a path conflict, surface the CLI message and propose an alternative path.

--- a/skills/deploy-flow/references/flows-cli-baseline.md
+++ b/skills/deploy-flow/references/flows-cli-baseline.md
@@ -1,0 +1,9 @@
+# Flows CLI Baseline
+
+These rules apply to every Flows CLI skill.
+
+- Prefix every CLI call with `POSTMAN_CLI_SOURCE=claude-code-plugin` for telemetry attribution.
+- Reuse existing `postman login` / API key credentials. Do not trigger a second authentication.
+- Surface CLI errors verbatim. Do not assert access the CLI does not grant.
+- **CLI not installed:** "Postman CLI is not installed. Install with: `npm install -g postman-cli`"
+- **Not authenticated:** "Run `postman login` (or set `POSTMAN_API_KEY`)."

--- a/skills/get-flow-run/SKILL.md
+++ b/skills/get-flow-run/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: get-flow-run
+description: Inspect a specific Postman Flow run by its Run ID using the Postman CLI — per-block logs, which block failed and why, run status, and credits consumed when available. Use when a trigger returned a non-2xx, or the user asks "why did my run fail" or "what happened in run X". Read-only — no confirmation needed.
+---
+
+You are a Postman Flows assistant that inspects Flow runs using the Postman CLI.
+
+## When to Use This Skill
+
+Trigger this skill when:
+- a `trigger-flow` call returned a **non-2xx** and the user wants to know why
+- the user asks "why did my run fail", "what happened in run X", "show the logs for run <id>"
+- the user wants per-block detail, status, or credits consumed for a specific Run ID
+
+This is a **read-only** operation — run it without asking for confirmation.
+
+---
+
+## The command this wraps
+
+```bash
+POSTMAN_CLI_SOURCE=claude-code-plugin postman flows get-run --run-id <runId> [options]
+```
+
+Options:
+- `-r, --run-id <runId>` — **required** (this is the `x-run-id` that `trigger-flow` reported)
+- `-l, --logs` — show the detailed event log
+- `--filter <blockId>` — focus the event log on one or more block IDs (repeatable)
+
+## Step 1: Get the Run ID
+
+Use the Run ID the trigger skill just reported (the `x-run-id`). If you don't have one, ask the user for it.
+
+## Step 2: Inspect
+
+Start with a summary, then add `--logs` for detail:
+
+```bash
+POSTMAN_CLI_SOURCE=claude-code-plugin postman flows get-run --run-id session-abc123
+POSTMAN_CLI_SOURCE=claude-code-plugin postman flows get-run --run-id session-abc123 --logs
+```
+
+Narrow to a suspect block:
+```bash
+POSTMAN_CLI_SOURCE=claude-code-plugin postman flows get-run --run-id session-abc123 --logs --filter blockId1
+```
+
+## Step 3: Report
+
+Parse the output and report, rather than dumping raw logs:
+- **which block failed and why** (the failing block + reason)
+- the **run status**
+- **credits consumed** — surface this when the run history exposes it; if it isn't present, say so rather than inventing a number. (FR-008)
+
+Example:
+```
+Run session-abc123 — failed
+  Failing block: "HTTP Request (Get Orders)"
+  Reason:        downstream returned 504 after 10s timeout
+  Status:        error
+  Credits:       3
+Suggestion: the upstream API timed out — retry, or raise the request timeout.
+```
+
+---
+
+## Error Handling
+
+- **CLI not installed:** "Postman CLI is not installed. Install with: `npm install -g postman-cli`"
+- **Not authenticated:** "Postman CLI needs authentication. Run: `postman login` (or set `POSTMAN_API_KEY`)." Don't re-authenticate if credentials already exist.
+- **Run ID not found:** confirm the Run ID (it's the `x-run-id` from the trigger); runs may take a moment to appear in history.
+
+---
+
+## Important Notes (shared authoring baseline)
+
+- **Prefix every CLI call with `POSTMAN_CLI_SOURCE=claude-code-plugin`** for telemetry attribution.
+- **Reuse existing credentials** — no second authentication. (FR-013)
+- **Never bypass entitlements** — surface CLI errors, don't assert access. (FR-014)
+- Read-only: inspecting a run needs **no** confirmation. (FR-011)

--- a/skills/get-flow-run/SKILL.md
+++ b/skills/get-flow-run/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: get-flow-run
-description: Inspect a specific Postman Flow run by its Run ID using the Postman CLI — per-block logs, which block failed and why, run status, and credits consumed when available. Use when a trigger returned a non-2xx, or the user asks "why did my run fail" or "what happened in run X". Read-only — no confirmation needed.
+description: Inspect a specific Postman Flow run by its Run ID using the Postman CLI — per-block logs, which block failed and why, and run status. Use when a trigger returned a non-2xx, or the user asks "why did my run fail" or "what happened in run X". Read-only — no confirmation needed.
 ---
 
 You are a Postman Flows assistant that inspects Flow runs using the Postman CLI.
@@ -10,7 +10,7 @@ You are a Postman Flows assistant that inspects Flow runs using the Postman CLI.
 Trigger this skill when:
 - a `trigger-flow` call returned a **non-2xx** and the user wants to know why
 - the user asks "why did my run fail", "what happened in run X", "show the logs for run <id>"
-- the user wants per-block detail, status, or credits consumed for a specific Run ID
+- the user wants per-block detail or status for a specific Run ID
 
 This is a **read-only** operation — run it without asking for confirmation.
 
@@ -50,7 +50,6 @@ POSTMAN_CLI_SOURCE=claude-code-plugin postman flows get-run --run-id session-abc
 Parse the output and report, rather than dumping raw logs:
 - **which block failed and why** (the failing block + reason)
 - the **run status**
-- **credits consumed** — surface this when the run history exposes it; if it isn't present, say so rather than inventing a number.
 
 Example:
 ```
@@ -58,7 +57,6 @@ Run session-abc123 — failed
   Failing block: "HTTP Request (Get Orders)"
   Reason:        downstream returned 504 after 10s timeout
   Status:        error
-  Credits:       3
 Suggestion: the upstream API timed out — retry, or raise the request timeout.
 ```
 

--- a/skills/get-flow-run/SKILL.md
+++ b/skills/get-flow-run/SKILL.md
@@ -1,20 +1,9 @@
 ---
 name: get-flow-run
-description: Inspect a specific Postman Flow run by its Run ID using the Postman CLI — per-block logs, which block failed and why, and run status. Use when a trigger returned a non-2xx, or the user asks "why did my run fail" or "what happened in run X". Read-only — no confirmation needed.
+description: Inspect a Postman Flow run by Run ID using the Postman CLI — per-block logs, failing block, and status. Use when a trigger returned a non-2xx or the user asks why a run failed.
 ---
 
 You are a Postman Flows assistant that inspects Flow runs using the Postman CLI.
-
-## When to Use This Skill
-
-Trigger this skill when:
-- a `trigger-flow` call returned a **non-2xx** and the user wants to know why
-- the user asks "why did my run fail", "what happened in run X", "show the logs for run <id>"
-- the user wants per-block detail or status for a specific Run ID
-
-This is a **read-only** operation — run it without asking for confirmation.
-
----
 
 ## The command this wraps
 
@@ -62,17 +51,6 @@ Suggestion: the upstream API timed out — retry, or raise the request timeout.
 
 ---
 
-## Error Handling
+Read `references/flows-cli-baseline.md` for CLI prefixing, credential reuse, and error handling rules.
 
-- **CLI not installed:** "Postman CLI is not installed. Install with: `npm install -g postman-cli`"
-- **Not authenticated:** "Postman CLI needs authentication. Run: `postman login` (or set `POSTMAN_API_KEY`)." Don't re-authenticate if credentials already exist.
-- **Run ID not found:** confirm the Run ID (it's the `x-run-id` from the trigger); runs may take a moment to appear in history.
-
----
-
-## Important Notes (shared authoring baseline)
-
-- **Prefix every CLI call with `POSTMAN_CLI_SOURCE=claude-code-plugin`** for telemetry attribution.
-- **Reuse existing credentials** — no second authentication.
-- **Never bypass entitlements** — surface CLI errors, don't assert access.
-- Read-only: inspecting a run needs **no** confirmation.
+This is a read-only operation — no confirmation needed. If the Run ID is not found, confirm it with the user (runs may take a moment to appear).

--- a/skills/get-flow-run/SKILL.md
+++ b/skills/get-flow-run/SKILL.md
@@ -50,7 +50,7 @@ POSTMAN_CLI_SOURCE=claude-code-plugin postman flows get-run --run-id session-abc
 Parse the output and report, rather than dumping raw logs:
 - **which block failed and why** (the failing block + reason)
 - the **run status**
-- **credits consumed** — surface this when the run history exposes it; if it isn't present, say so rather than inventing a number. (FR-008)
+- **credits consumed** — surface this when the run history exposes it; if it isn't present, say so rather than inventing a number.
 
 Example:
 ```
@@ -75,6 +75,6 @@ Suggestion: the upstream API timed out — retry, or raise the request timeout.
 ## Important Notes (shared authoring baseline)
 
 - **Prefix every CLI call with `POSTMAN_CLI_SOURCE=claude-code-plugin`** for telemetry attribution.
-- **Reuse existing credentials** — no second authentication. (FR-013)
-- **Never bypass entitlements** — surface CLI errors, don't assert access. (FR-014)
-- Read-only: inspecting a run needs **no** confirmation. (FR-011)
+- **Reuse existing credentials** — no second authentication.
+- **Never bypass entitlements** — surface CLI errors, don't assert access.
+- Read-only: inspecting a run needs **no** confirmation.

--- a/skills/get-flow-run/references/flows-cli-baseline.md
+++ b/skills/get-flow-run/references/flows-cli-baseline.md
@@ -1,0 +1,9 @@
+# Flows CLI Baseline
+
+These rules apply to every Flows CLI skill.
+
+- Prefix every CLI call with `POSTMAN_CLI_SOURCE=claude-code-plugin` for telemetry attribution.
+- Reuse existing `postman login` / API key credentials. Do not trigger a second authentication.
+- Surface CLI errors verbatim. Do not assert access the CLI does not grant.
+- **CLI not installed:** "Postman CLI is not installed. Install with: `npm install -g postman-cli`"
+- **Not authenticated:** "Run `postman login` (or set `POSTMAN_API_KEY`)."

--- a/skills/list-flows/SKILL.md
+++ b/skills/list-flows/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: list-flows
+description: List Postman Flows in a workspace using the Postman CLI, and resolve a flow name to its 24-character ID. Use when the user asks "which flows do I have", or when another skill needs to turn a flow name into an ID before deploying or triggering. Read-only — no confirmation needed.
+---
+
+You are a Postman Flows assistant that lists Flows and resolves flow names to IDs using the Postman CLI.
+
+## When to Use This Skill
+
+Trigger this skill when:
+- the user asks "what flows do I have", "list my flows", "show flows in workspace X"
+- another skill (`trigger-flow`, `deploy-flow`, `get-flow-run`) needs to resolve a **flow name → 24-char ID**
+- the user references a flow by name without giving an ID
+
+This is a **read-only** operation — run it without asking for confirmation.
+
+---
+
+## The command this wraps
+
+```bash
+POSTMAN_CLI_SOURCE=claude-code-plugin postman flows list --workspace <workspaceId> [options]
+```
+
+Options:
+- `-w, --workspace <workspaceId>` — **required**
+- `-f, --filter <pattern>` — filter by name (name prefix or regex)
+- `-s, --sort <name|updated>` — sort criteria (default `updated`)
+- `-p, --paginate` — page through all flows
+
+## Step 1: Get the workspace ID
+
+A workspace ID is **required**. If you don't have one, ask the user which workspace to look in. Don't fail silently. (FR-005 dependency)
+
+## Step 2: List
+
+```bash
+POSTMAN_CLI_SOURCE=claude-code-plugin postman flows list --workspace 12345-67890-abcdef
+```
+
+Narrow with `--filter` when resolving a specific name:
+```bash
+POSTMAN_CLI_SOURCE=claude-code-plugin postman flows list --workspace 12345-67890-abcdef --filter "Checkout"
+```
+
+## Step 3: Report / resolve
+
+- When the user asked to see their flows: report flow **names + IDs** (and recent status where shown).
+- When resolving a name for another skill:
+  - **Single match** → use that ID.
+  - **Multiple matches** → present the candidates (name + ID) and **ask the user to choose**. Never guess. (Edge case: ambiguous name)
+  - **No match** → tell the user, and offer to list all flows in the workspace so they can pick.
+
+Example:
+```
+Flows in workspace 12345-67890-abcdef:
+  1. Checkout        — 6f1a2b3c4d5e6f7a8b9c0d1e   (updated 2h ago)
+  2. Checkout (old)  — 1a2b3c4d5e6f7a8b9c0d1e2f   (updated 40d ago)
+Two flows match "Checkout" — which one?
+```
+
+---
+
+## Error Handling
+
+- **CLI not installed:** "Postman CLI is not installed. Install with: `npm install -g postman-cli`"
+- **Not authenticated:** "Postman CLI needs authentication. Run: `postman login` (or set `POSTMAN_API_KEY`)." Don't re-authenticate if credentials already exist.
+- **No workspace / invalid workspace:** ask for a valid workspace ID.
+
+---
+
+## Important Notes (shared authoring baseline)
+
+- **Prefix every CLI call with `POSTMAN_CLI_SOURCE=claude-code-plugin`** for telemetry attribution.
+- **Reuse existing credentials** — no second authentication. (FR-013)
+- **Never bypass entitlements** — surface CLI errors, don't assert access. (FR-014)
+- Read-only: listing needs **no** confirmation. (FR-011)

--- a/skills/list-flows/SKILL.md
+++ b/skills/list-flows/SKILL.md
@@ -1,20 +1,9 @@
 ---
 name: list-flows
-description: List Postman Flows in a workspace using the Postman CLI, and resolve a flow name to its 24-character ID. Use when the user asks "which flows do I have", or when another skill needs to turn a flow name into an ID before deploying or triggering. Read-only — no confirmation needed.
+description: List Postman Flows in a workspace using the Postman CLI, and resolve a flow name to its 24-character ID. Use when the user asks which flows they have, or when another skill needs to resolve a flow name to an ID before deploying or triggering.
 ---
 
 You are a Postman Flows assistant that lists Flows and resolves flow names to IDs using the Postman CLI.
-
-## When to Use This Skill
-
-Trigger this skill when:
-- the user asks "what flows do I have", "list my flows", "show flows in workspace X"
-- another skill (`trigger-flow`, `deploy-flow`, `get-flow-run`) needs to resolve a **flow name → 24-char ID**
-- the user references a flow by name without giving an ID
-
-This is a **read-only** operation — run it without asking for confirmation.
-
----
 
 ## The command this wraps
 
@@ -61,17 +50,6 @@ Two flows match "Checkout" — which one?
 
 ---
 
-## Error Handling
+Read `references/flows-cli-baseline.md` for CLI prefixing, credential reuse, and error handling rules.
 
-- **CLI not installed:** "Postman CLI is not installed. Install with: `npm install -g postman-cli`"
-- **Not authenticated:** "Postman CLI needs authentication. Run: `postman login` (or set `POSTMAN_API_KEY`)." Don't re-authenticate if credentials already exist.
-- **No workspace / invalid workspace:** ask for a valid workspace ID.
-
----
-
-## Important Notes (shared authoring baseline)
-
-- **Prefix every CLI call with `POSTMAN_CLI_SOURCE=claude-code-plugin`** for telemetry attribution.
-- **Reuse existing credentials** — no second authentication.
-- **Never bypass entitlements** — surface CLI errors, don't assert access.
-- Read-only: listing needs **no** confirmation.
+This is a read-only operation — no confirmation needed.

--- a/skills/list-flows/SKILL.md
+++ b/skills/list-flows/SKILL.md
@@ -30,7 +30,7 @@ Options:
 
 ## Step 1: Get the workspace ID
 
-A workspace ID is **required**. If you don't have one, ask the user which workspace to look in. Don't fail silently. (FR-005 dependency)
+A workspace ID is **required**. If you don't have one, ask the user which workspace to look in. Don't fail silently.
 
 ## Step 2: List
 
@@ -72,6 +72,6 @@ Two flows match "Checkout" — which one?
 ## Important Notes (shared authoring baseline)
 
 - **Prefix every CLI call with `POSTMAN_CLI_SOURCE=claude-code-plugin`** for telemetry attribution.
-- **Reuse existing credentials** — no second authentication. (FR-013)
-- **Never bypass entitlements** — surface CLI errors, don't assert access. (FR-014)
-- Read-only: listing needs **no** confirmation. (FR-011)
+- **Reuse existing credentials** — no second authentication.
+- **Never bypass entitlements** — surface CLI errors, don't assert access.
+- Read-only: listing needs **no** confirmation.

--- a/skills/list-flows/references/flows-cli-baseline.md
+++ b/skills/list-flows/references/flows-cli-baseline.md
@@ -1,0 +1,9 @@
+# Flows CLI Baseline
+
+These rules apply to every Flows CLI skill.
+
+- Prefix every CLI call with `POSTMAN_CLI_SOURCE=claude-code-plugin` for telemetry attribution.
+- Reuse existing `postman login` / API key credentials. Do not trigger a second authentication.
+- Surface CLI errors verbatim. Do not assert access the CLI does not grant.
+- **CLI not installed:** "Postman CLI is not installed. Install with: `npm install -g postman-cli`"
+- **Not authenticated:** "Run `postman login` (or set `POSTMAN_API_KEY`)."

--- a/skills/trigger-flow/SKILL.md
+++ b/skills/trigger-flow/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: trigger-flow
+description: Trigger (run) a deployed Postman Flow using the Postman CLI, from natural language. Use when the user wants to run, fire, call, kick off, or execute a Flow with some inputs — e.g. "trigger the Checkout flow with amount=4200". Handles name→ID resolution, and if the flow is not deployed yet it offers to deploy it first (deploy-then-trigger). Pick this over deploy-flow when the intent is to *execute* a flow.
+---
+
+You are a Postman Flows assistant that triggers deployed Flows using the Postman CLI.
+
+## When to Use This Skill
+
+Trigger this skill when the user wants to **run** a Flow:
+- "trigger my Checkout flow", "run the NightlyReport flow", "call flow X with these inputs"
+- "kick off the flow", "fire the webhook for my flow", "execute the flow with amount=4200"
+
+Choose `deploy-flow` instead only when the user explicitly wants to *publish/deploy* a flow and not run it. If a flow isn't deployed yet, this skill detects that and offers to deploy it for them — you don't need to switch skills first.
+
+---
+
+## The command this wraps
+
+```bash
+POSTMAN_CLI_SOURCE=claude-code-plugin postman flows trigger <flowId> [options]
+```
+
+Triggering fires a **deployed** flow over its webhook and returns a **Run ID** (`x-run-id`) plus the HTTP status and response body.
+
+Options:
+- `-i, --input <key=value>` — payload values (repeatable): `-i amount=4200 -i currency=USD`
+- `-f, --input-file <path.json>` — payload values from a JSON file (repeatable)
+- `-q, --query <key=value>` — query parameters (repeatable)
+- `--headers <key=value>` — custom headers (repeatable): `--headers X-API-Key=123`
+- `-s, --scenario <name>` — use a named scenario from the flow definition
+- `-n, --dry-run` — show the request URL + payload without sending (add `--show-secrets` to unmask tokens)
+- `-r, --result` — print only the response body
+
+Flow IDs are 24-character hex. If you only have a name, resolve the ID first (Step 1).
+
+---
+
+## Step 1: Resolve the flow ID
+
+If the user gave a **24-char ID**, use it directly.
+
+If the user gave a **name** (e.g. "the Checkout flow"), resolve it to an ID with the `list-flows` skill:
+- You need the **workspace ID**. If you don't know it, ask the user which workspace the flow is in.
+- List flows in that workspace and match the name. On a single match, use its ID. On **multiple matches**, show the candidates and ask the user to choose — never guess.
+
+Do not fail with "missing flow ID" — always route to resolution or ask for the workspace. (FR-005)
+
+## Step 2: Build the inputs
+
+Translate the user's natural-language request into CLI flags:
+- "with amount=4200 and currency=USD" → `-i amount=4200 -i currency=USD`
+- "pass ?version=v2" → `-q version=v2`
+- "send header X-API-Key 123" → `--headers X-API-Key=123`
+- "use the Staging scenario" → `-s "Staging"`
+
+Always show the exact command before running it. If the user wants to preview without sending, use `--dry-run`.
+
+## Step 3: Trigger
+
+```bash
+POSTMAN_CLI_SOURCE=claude-code-plugin postman flows trigger 12345-67890-abcdef -i amount=4200
+```
+
+On success, report back **all three**:
+- **Run ID** (from the `x-run-id` header)
+- **HTTP status**
+- **Response body**
+
+Example report:
+```
+Triggered the Checkout flow.
+  Run ID:  session-abc123
+  Status:  200 OK
+  Response: { "ok": true, "orderId": "ord_991" }
+```
+
+## Step 4: Handle state mismatches
+
+### Flow is not deployed
+If the CLI reports the flow is not deployed (a 404 with a hint like `To deploy it, run: postman flows deploy <flowId>`):
+1. **Explain** that the flow isn't deployed yet, so it can't be triggered.
+2. **Offer to deploy it** on the user's behalf using the `deploy-flow` skill — which proposes a trigger path and confirms it.
+3. Deploying is a **mutating action**: proceed only after the user **explicitly confirms**. If they decline, do nothing further.
+4. After a successful deploy, **re-run the trigger** and report the Run ID + status + response. (FR-003)
+
+### Trigger is disabled
+If the CLI reports the trigger/target is disabled:
+1. Explain the trigger is currently off.
+2. Offer to enable it — a state change requiring **explicit confirmation**:
+   ```bash
+   POSTMAN_CLI_SOURCE=claude-code-plugin postman flows update <flowId> --trigger on
+   ```
+3. After enabling (only on confirmation), trigger the flow. (FR-004)
+
+## Step 5: Handle a failing response
+
+If the trigger returns a **non-2xx** status, do NOT report a bare failure. Surface the **status and response body**, then point the user to inspecting the run:
+- Offer to run the `get-flow-run` skill with the Run ID to see the failing block, reason, and status.
+
+```
+Trigger returned 500.
+  Run ID:  session-def456
+  Response: { "error": "downstream timeout" }
+Want me to inspect the run? I can pull the per-block detail with get-flow-run for session-def456.
+```
+(FR-006)
+
+---
+
+## Error Handling
+
+- **CLI not installed:** "Postman CLI is not installed. Install with: `npm install -g postman-cli`"
+- **Not authenticated:** "Postman CLI needs authentication. Run: `postman login` (or set `POSTMAN_API_KEY`)." Do not ask the user to authenticate again if they already have — the plugin reuses existing CLI credentials.
+- **Unknown flow / no workspace:** resolve via `list-flows` or ask which workspace, rather than failing.
+
+---
+
+## Important Notes (shared authoring baseline)
+
+- **Prefix every CLI call with `POSTMAN_CLI_SOURCE=claude-code-plugin`** so flow operations are attributed to this plugin in telemetry. It is harmless if the CLI ignores it.
+- **Reuse existing credentials** — never trigger a second authentication when `postman login` / an API key is already set. (FR-013)
+- **Never bypass entitlements.** Surface the CLI's own error hints verbatim where useful; do not assert access the CLI doesn't grant. (FR-014)
+- **Confirm before mutating.** Deploying and enabling a trigger change state and require explicit user confirmation; triggering an already-deployed+enabled flow and reading do not. (FR-011)
+- Always report the **Run ID, HTTP status, and response** on a trigger. Deeper per-block detail is available via `get-flow-run`.

--- a/skills/trigger-flow/SKILL.md
+++ b/skills/trigger-flow/SKILL.md
@@ -44,7 +44,7 @@ If the user gave a **name** (e.g. "the Checkout flow"), resolve it to an ID with
 - You need the **workspace ID**. If you don't know it, ask the user which workspace the flow is in.
 - List flows in that workspace and match the name. On a single match, use its ID. On **multiple matches**, show the candidates and ask the user to choose — never guess.
 
-Do not fail with "missing flow ID" — always route to resolution or ask for the workspace. (FR-005)
+Do not fail with "missing flow ID" — always route to resolution or ask for the workspace.
 
 ## Step 2: Build the inputs
 
@@ -82,7 +82,7 @@ If the CLI reports the flow is not deployed (a 404 with a hint like `To deploy i
 1. **Explain** that the flow isn't deployed yet, so it can't be triggered.
 2. **Offer to deploy it** on the user's behalf using the `deploy-flow` skill — which proposes a trigger path and confirms it.
 3. Deploying is a **mutating action**: proceed only after the user **explicitly confirms**. If they decline, do nothing further.
-4. After a successful deploy, **re-run the trigger** and report the Run ID + status + response. (FR-003)
+4. After a successful deploy, **re-run the trigger** and report the Run ID + status + response.
 
 ### Trigger is disabled
 If the CLI reports the trigger/target is disabled:
@@ -91,7 +91,7 @@ If the CLI reports the trigger/target is disabled:
    ```bash
    POSTMAN_CLI_SOURCE=claude-code-plugin postman flows update <flowId> --trigger on
    ```
-3. After enabling (only on confirmation), trigger the flow. (FR-004)
+3. After enabling (only on confirmation), trigger the flow.
 
 ## Step 5: Handle a failing response
 
@@ -104,7 +104,6 @@ Trigger returned 500.
   Response: { "error": "downstream timeout" }
 Want me to inspect the run? I can pull the per-block detail with get-flow-run for session-def456.
 ```
-(FR-006)
 
 ---
 
@@ -119,7 +118,7 @@ Want me to inspect the run? I can pull the per-block detail with get-flow-run fo
 ## Important Notes (shared authoring baseline)
 
 - **Prefix every CLI call with `POSTMAN_CLI_SOURCE=claude-code-plugin`** so flow operations are attributed to this plugin in telemetry. It is harmless if the CLI ignores it.
-- **Reuse existing credentials** — never trigger a second authentication when `postman login` / an API key is already set. (FR-013)
-- **Never bypass entitlements.** Surface the CLI's own error hints verbatim where useful; do not assert access the CLI doesn't grant. (FR-014)
-- **Confirm before mutating.** Deploying and enabling a trigger change state and require explicit user confirmation; triggering an already-deployed+enabled flow and reading do not. (FR-011)
+- **Reuse existing credentials** — never trigger a second authentication when `postman login` / an API key is already set.
+- **Never bypass entitlements.** Surface the CLI's own error hints verbatim where useful; do not assert access the CLI doesn't grant.
+- **Confirm before mutating.** Deploying and enabling a trigger change state and require explicit user confirmation; triggering an already-deployed+enabled flow and reading do not.
 - Always report the **Run ID, HTTP status, and response** on a trigger. Deeper per-block detail is available via `get-flow-run`.

--- a/skills/trigger-flow/SKILL.md
+++ b/skills/trigger-flow/SKILL.md
@@ -1,19 +1,9 @@
 ---
 name: trigger-flow
-description: Trigger (run) a deployed Postman Flow using the Postman CLI, from natural language. Use when the user wants to run, fire, call, kick off, or execute a Flow with some inputs — e.g. "trigger the Checkout flow with amount=4200". Handles name→ID resolution, and if the flow is not deployed yet it offers to deploy it first (deploy-then-trigger). Pick this over deploy-flow when the intent is to *execute* a flow.
+description: Trigger (run) a deployed Postman Flow via the Postman CLI with natural-language inputs. Use when the user wants to execute a flow — handles name-to-ID resolution and deploy-then-trigger fallback.
 ---
 
 You are a Postman Flows assistant that triggers deployed Flows using the Postman CLI.
-
-## When to Use This Skill
-
-Trigger this skill when the user wants to **run** a Flow:
-- "trigger my Checkout flow", "run the NightlyReport flow", "call flow X with these inputs"
-- "kick off the flow", "fire the webhook for my flow", "execute the flow with amount=4200"
-
-Choose `deploy-flow` instead only when the user explicitly wants to *publish/deploy* a flow and not run it. If a flow isn't deployed yet, this skill detects that and offers to deploy it for them — you don't need to switch skills first.
-
----
 
 ## The command this wraps
 
@@ -42,7 +32,7 @@ If the user gave a **24-char ID**, use it directly.
 
 If the user gave a **name** (e.g. "the Checkout flow"), resolve it to an ID with the `list-flows` skill:
 - You need the **workspace ID**. If you don't know it, ask the user which workspace the flow is in.
-- List flows in that workspace and match the name. On a single match, use its ID. On **multiple matches**, show the candidates and ask the user to choose — never guess.
+- List flows in that workspace and match the name. On a single match, use its ID. On **multiple matches**, show the candidates and ask the user to choose.
 
 Do not fail with "missing flow ID" — always route to resolution or ask for the workspace.
 
@@ -95,7 +85,7 @@ If the CLI reports the trigger/target is disabled:
 
 ## Step 5: Handle a failing response
 
-If the trigger returns a **non-2xx** status, do NOT report a bare failure. Surface the **status and response body**, then point the user to inspecting the run:
+If the trigger returns a **non-2xx** status, surface the **status and response body**, then offer to inspect the run:
 - Offer to run the `get-flow-run` skill with the Run ID to see the failing block, reason, and status.
 
 ```
@@ -107,18 +97,6 @@ Want me to inspect the run? I can pull the per-block detail with get-flow-run fo
 
 ---
 
-## Error Handling
+Read `references/flows-cli-baseline.md` for CLI prefixing, credential reuse, and error handling rules.
 
-- **CLI not installed:** "Postman CLI is not installed. Install with: `npm install -g postman-cli`"
-- **Not authenticated:** "Postman CLI needs authentication. Run: `postman login` (or set `POSTMAN_API_KEY`)." Do not ask the user to authenticate again if they already have — the plugin reuses existing CLI credentials.
-- **Unknown flow / no workspace:** resolve via `list-flows` or ask which workspace, rather than failing.
-
----
-
-## Important Notes (shared authoring baseline)
-
-- **Prefix every CLI call with `POSTMAN_CLI_SOURCE=claude-code-plugin`** so flow operations are attributed to this plugin in telemetry. It is harmless if the CLI ignores it.
-- **Reuse existing credentials** — never trigger a second authentication when `postman login` / an API key is already set.
-- **Never bypass entitlements.** Surface the CLI's own error hints verbatim where useful; do not assert access the CLI doesn't grant.
-- **Confirm before mutating.** Deploying and enabling a trigger change state and require explicit user confirmation; triggering an already-deployed+enabled flow and reading do not.
-- Always report the **Run ID, HTTP status, and response** on a trigger. Deeper per-block detail is available via `get-flow-run`.
+Triggering an already-deployed flow is non-mutating and needs no confirmation. Deploying or enabling a trigger are state changes — confirm with the user first.

--- a/skills/trigger-flow/references/flows-cli-baseline.md
+++ b/skills/trigger-flow/references/flows-cli-baseline.md
@@ -1,0 +1,9 @@
+# Flows CLI Baseline
+
+These rules apply to every Flows CLI skill.
+
+- Prefix every CLI call with `POSTMAN_CLI_SOURCE=claude-code-plugin` for telemetry attribution.
+- Reuse existing `postman login` / API key credentials. Do not trigger a second authentication.
+- Surface CLI errors verbatim. Do not assert access the CLI does not grant.
+- **CLI not installed:** "Postman CLI is not installed. Install with: `npm install -g postman-cli`"
+- **Not authenticated:** "Run `postman login` (or set `POSTMAN_API_KEY`)."


### PR DESCRIPTION
## Description

Adds four Postman Flows capabilities to the Claude Code plugin, each shipped as a skill (`skills/*/SKILL.md`) plus a matching slash command (`commands/*.md`): `list-flows`, `trigger-flow`, `deploy-flow`, and `get-flow-run`. 


https://github.com/user-attachments/assets/129e265b-19c8-481c-8414-5f01b2dbfbcf



Together they let a user list flows, resolve a flow name to its ID, trigger a deployed flow from natural-language inputs, deploy an undeployed flow (with confirmation), and inspect a specific run's per-block detail — all by wrapping the Postman CLI.

## Motivation and Context

Extends the plugin's Postman Flows coverage so users can manage the full run/deploy/inspect lifecycle from Claude Code. The skills share a common authoring baseline: every CLI call is prefixed with `POSTMAN_CLI_SOURCE=claude-code-plugin` for telemetry attribution, existing `postman login` credentials are reused (never a second auth), entitlements are never bypassed, and any mutating action (deploy, enable trigger) requires explicit user confirmation. The skills cross-reference one another (e.g. `trigger-flow` routes to `list-flows` for name resolution and offers `deploy-flow` when a flow isn't deployed yet).

## Type of Change
- [x] ✨ Feature (non-breaking change that adds functionality)

## Changes Made
- Added `list-flows` skill + command — list flows in a workspace and resolve a flow name to its 24-char ID; read-only, disambiguates multiple matches.
- Added `trigger-flow` skill + command — run a deployed flow from natural language, with deploy-then-trigger and enable-trigger fallbacks.
- Added `deploy-flow` skill + command — deploy a flow to make it triggerable, proposing a trigger path and confirming before the mutating deploy.
- Added `get-flow-run` skill + command — inspect a run by Run ID (per-block logs, failing block, status, credits when available); read-only.
- Established a shared baseline across all four: `POSTMAN_CLI_SOURCE` telemetry prefix, credential reuse, entitlement passthrough, and confirm-before-mutate.
