### PR TITLE
Update install instructions to prefer claude plugin install

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,24 +13,27 @@ The Postman Plugin provides a single, simple install for Claude Code. It provide
 
 ## Installation
 
-Clone the repo and load it as a local plugin:
+Install directly from GitHub:
+
+```bash
+claude plugin install github:Postman-Devrel/postman-claude-code-plugin
+```
+
+<details>
+<summary>Alternative: load from a local clone</summary>
 
 ```bash
 git clone https://github.com/Postman-Devrel/postman-claude-code-plugin.git
-```
-
-Then start Claude Code with the plugin loaded:
-
-```bash
 cd your-api-project/
 claude --plugin-dir /path/to/postman-claude-code-plugin
 ```
+</details>
 
 ## Quick Start
 
-1. Start Claude Code with the plugin:
+1. Start Claude Code:
 ```bash
-claude --plugin-dir /path/to/postman-claude-code-plugin
+claude
 ```
 
 2. Run setup:


### PR DESCRIPTION
## Summary
- Makes `claude plugin install github:Postman-Devrel/postman-claude-code-plugin` the primary install method
- Moves the clone + `--plugin-dir` approach into a collapsible Alternative section
- Simplifies Quick Start step 1 since installed plugins don't need `--plugin-dir`

## Test plan
- [ ] Verify README renders correctly on GitHub (collapsible section, code blocks)

Generated with [Claude Code](https://claude.com/claude-code)